### PR TITLE
Fix syntax errors (under vim 9.0)

### DIFF
--- a/plugin/ColorSchemeMenuMaker.vim
+++ b/plugin/ColorSchemeMenuMaker.vim
@@ -312,7 +312,7 @@ function! <SID>IsMagenta(r, g, b, h, s, v) "{{{
     else 
         return 0
     endif
-endfunction }}}
+endfunction "}}}
 
 function! <SID>IsOrange(r, g, b, h, s, v) "{{{
     "a magic number found through trial and error
@@ -742,7 +742,7 @@ unlet s:keepcpo
 "}}}1
 
 "Detect absence of ColorScheme menu, and generate a new one automatically
-if has("gui_running") && !filereadable(s:menuFile) "{{{
+if (has("gui_running") && !filereadable(s:menuFile)) "{{{
     echomsg "Creating ColorScheme menu - Please Wait..."
     call <SID>InitMenu()
     echomsg "Done!"


### PR DESCRIPTION
These errors have existed for a few years and I've always just patched my local copy, but time I gave back...

Error 1:
> Error detected while processing ~/.vim/bundle/ColorSchemeMenuMaker/plugin/ColorSchemeMenuMaker.vim:
> line  315:
> E488: Trailing characters: }: }}

Issue: missing quote character in front of closing fold braces

Error 2:
> Error detected while processing ~/.vim/bundle/ColorSchemeMenuMaker/plugin/ColorSchemeMenuMaker.vim[747]..function <SNR>41_InitMenu[1]..WriteColorSchemeMenu[3]..<SNR>41_ScanThemeBackgrounds[5]..<SNR>41_RgbTxt2Hexes:

Issue: Missing parens around compound if conditional